### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,7 +7,7 @@ MatrixCopy	KEYWORD2
 MatrixMult	KEYWORD2
 mesh	KEYWORD2
 depthMap	KEYWORD2
-init KEYWORD2
+init	KEYWORD2
 Translate	KEYWORD2
 Rotate	KEYWORD2
 Scale	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords